### PR TITLE
fix(client): encode generated json request bodies

### DIFF
--- a/lib/src/builder/client_generator.dart
+++ b/lib/src/builder/client_generator.dart
@@ -687,6 +687,7 @@ String _routeEntry(
   };
   final imports = [
     if (node.routes.isNotEmpty) "import 'dart:async';",
+    if (node.routes.any(routeDataTypes.containsKey)) "import 'dart:convert';",
     "import 'package:spry/client.dart';",
     for (final import in paramImports) "import '$import';",
     for (final import in inputImports) "import '$import';",
@@ -945,7 +946,7 @@ String _callBody(
   Map<RouteEntry, _ClientTypedArtifactRef> routeOutputTypes,
 ) {
   final buffer = StringBuffer();
-  buffer.write(_headersPrelude(route, routeHeaderTypes));
+  buffer.write(_headersPrelude(route, routeDataTypes, routeHeaderTypes));
   buffer.write(_pathPrelude(node, route));
   buffer.writeln('    final request = Request(');
   buffer.writeln('      ${_requestInputExpression(route, routeQueryTypes)},');
@@ -960,6 +961,7 @@ String _callBody(
 
 String _headersPrelude(
   RouteEntry route,
+  Map<RouteEntry, _ClientTypedArtifactRef> routeDataTypes,
   Map<RouteEntry, _ClientTypedArtifactRef> routeHeaderTypes,
 ) {
   final buffer = StringBuffer()
@@ -986,6 +988,16 @@ String _headersPrelude(
     ..writeln('        requestHeaders.set(key, value);')
     ..writeln('      }')
     ..writeln('    }');
+  if (routeDataTypes[route] != null) {
+    buffer
+      ..writeln(
+        "    if (body == null && data != null && !requestHeaders.has('content-type')) {",
+      )
+      ..writeln(
+        "      requestHeaders.set('content-type', 'application/json; charset=utf-8');",
+      )
+      ..writeln('    }');
+  }
   return buffer.toString();
 }
 
@@ -1024,7 +1036,7 @@ String _requestBodyExpression(
   if (routeDataTypes[route] == null) {
     return 'body';
   }
-  return 'body ?? data?.toJson()';
+  return 'body ?? (data == null ? null : jsonEncode(data.toJson()))';
 }
 
 String _pathPrelude(_ClientRouteNode node, RouteEntry route) {

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -1369,6 +1369,7 @@ Response handler(Event _) => Response('uploaded');
         userInputsSource,
         contains("'startsAt': startsAt.toIso8601String(),"),
       );
+      expect(userRoutesSource, contains("import 'dart:convert';"));
       expect(
         userRoutesSource,
         contains("import '../../inputs/users/index.post.dart';"),
@@ -1382,7 +1383,19 @@ Response handler(Event _) => Response('uploaded');
       expect(
         userRoutesSource,
         contains(
-          '.new(method: HttpMethod.post, headers: requestHeaders, body: body ?? data?.toJson())',
+          "if (body == null && data != null && !requestHeaders.has('content-type')) {",
+        ),
+      );
+      expect(
+        userRoutesSource,
+        contains(
+          "requestHeaders.set('content-type', 'application/json; charset=utf-8');",
+        ),
+      );
+      expect(
+        userRoutesSource,
+        contains(
+          '.new(method: HttpMethod.post, headers: requestHeaders, body: body ?? (data == null ? null : jsonEncode(data.toJson())))',
         ),
       );
       expect(


### PR DESCRIPTION
Resolves #195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON request serialization in generated HTTP clients: request bodies are now properly JSON-encoded, and `application/json; charset=utf-8` content-type headers are automatically set when sending typed data without explicit headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->